### PR TITLE
FIX bug ft_freef

### DIFF
--- a/src/utils/ft_freef.c
+++ b/src/utils/ft_freef.c
@@ -20,7 +20,7 @@ void	*ft_freef(const char *formats, ...)
 			{
 				dptr = va_arg(ap, void **);
 				i = 0;
-				while (dptr[i] != NULL)
+				while (dptr != NULL dptr[i] != NULL)
 					free(dptr[i++]);
 				free(dptr);
 			}


### PR DESCRIPTION
this commit add a protection for the case when we send a **dptr == NULL
