### PR TITLE
FIX bug signal-reprompt

### DIFF
--- a/include/msh_signal.h
+++ b/include/msh_signal.h
@@ -1,5 +1,5 @@
-#ifndef MSH_SIGNALS_H
-# define MSH_SIGNALS_H
+#ifndef MSH_SIGNAL_H
+# define MSH_SIGNAL_H
 
 # include <signal.h>
 

--- a/src/exec/exec.c
+++ b/src/exec/exec.c
@@ -42,7 +42,6 @@ static int	ft_init_exl(t_exl *exl, t_msh *msh, t_pipeline *pipeline)
 	exl->line_num = &msh->line_num;
 	exl->cmd_idx = -1;
 	exl->n_cmd = pipeline->n_cmd;
-	g_signal_value = 0;
 	return (ft_heredoc(pipeline->cmd_list, exl));
 }
 

--- a/src/exec/run.c
+++ b/src/exec/run.c
@@ -7,11 +7,14 @@
 
 void	ft_run(t_msh *msh);
 
+sig_atomic_t	g_signal_value;
+
 void	ft_run(t_msh *msh)
 {
 	t_pipeline	s_pipeline;
 	char		*line;
 
+	g_signal_value = 0;
 	while (true)
 	{
 		ft_set_signals(MSH_SIG_REPROMPT);
@@ -20,6 +23,7 @@ void	ft_run(t_msh *msh)
 		ft_set_signals(MSH_SIG_IGN);
 		if (line == NULL)
 			return ;
+		g_signal_value = 0;
 		if (*line != '\0')
 		{
 			add_history(line);

--- a/src/heredoc/retrieve_hd_content.c
+++ b/src/heredoc/retrieve_hd_content.c
@@ -53,7 +53,10 @@ static bool	ft_end_of_hd(char *current_line, char *del, unsigned int line_num)
 	if (current_line == NULL || ft_strcmp(current_line, del) == 0)
 	{
 		if (current_line == NULL)
+		{
 			printf("msh: warning: here-document at line %d delimited by end-of-file (wanted `%s')\n", line_num, del);
+			g_signal_value = EOF;
+		}
 		else
 			free(current_line);
 		return (true);

--- a/src/signals/set_signals.c
+++ b/src/signals/set_signals.c
@@ -8,8 +8,6 @@ static void	ft_set_sighandler_heredoc(void);
 static void	ft_set_sighandler_ext_cmd(void);
 static void	ft_set_sighandler_reprompt(void);
 
-sig_atomic_t	g_signal_value;
-
 void	ft_set_signals(t_msh_signals e_msh_signals)
 {
 	void	(*f[4])(void);

--- a/src/signals/sighandlers.c
+++ b/src/signals/sighandlers.c
@@ -26,7 +26,8 @@ void	ft_sighandler_heredoc(int sig)
 void	ft_sighandler_reprompt(int sig)
 {
 	(void)sig;
-	write(1, "\n", 1);
+	if (g_signal_value != EOF)
+		write(1, "\n", 1);
 	rl_replace_line("", 0);
 	rl_on_new_line();
 	rl_redisplay();


### PR DESCRIPTION
fix the bug when ctrl-d is pressed in a heredoc that cause sighandler reprompt to print a blank newline
