### PR TITLE
REFACTOR env to linked list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ SRCS_FILES:=	exec/child_process				\
 				exec/run						\
 				heredoc/heredoc					\
 				heredoc/retrieve_hd_content		\
+				init_and_destroy/env_init		\
 				init_and_destroy/struct_destroy	\
 				init_and_destroy/struct_init	\
 				parsing/parse					\
@@ -84,6 +85,7 @@ SRCS_FILES:=	exec/child_process				\
 				utils/ft_dptr					\
 				utils/ft_freef					\
 				utils/ft_join					\
+				utils/ft_memcpy					\
 				utils/ft_putendl_fd				\
 				utils/ft_putstr_fd				\
 				utils/ft_split					\
@@ -91,6 +93,7 @@ SRCS_FILES:=	exec/child_process				\
 				utils/ft_strdup					\
 				utils/ft_strlen					\
 				utils/ft_strncmp				\
+				utils/ft_strndup				\
 				utils/ft_substr					\
 				utils/ft_umaxtostr				\
 				utils/ft_lst/ft_lstadd_back		\

--- a/include/exec.h
+++ b/include/exec.h
@@ -2,6 +2,7 @@
 # define EXEC_H
 
 # include "parse.h"
+# include "list.h"
 # include <stdbool.h>
 
 # define COMMAND_NOT_EXECUTABLE 126
@@ -11,9 +12,23 @@
 # define HD_PROMPT "> "
 # define MSH_ERROR_PROMPT "minishell: "
 
+typedef struct var
+{
+	char	*name;
+	char	*value;
+	bool	exported;
+}				t_var;
+
+typedef struct list
+{
+	t_list_node	*list_node;
+	t_list_node	*last_node;
+	size_t		n_exported;
+}				t_list;
+
 typedef struct msh
 {
-	char			**env;
+	t_list			env;
 	char			**path;
 	int				exit_status;
 	unsigned int	line_num;
@@ -27,7 +42,7 @@ typedef struct fd_io
 
 typedef struct exl
 {
-	char			**env;
+	t_list			*env;
 	char			**path;
 	int				pipe[2];
 	t_fd_io			s_fd_io;
@@ -45,7 +60,7 @@ int		ft_exec_line(t_msh *msh, t_pipeline *pipeline);
 char	*ft_get_cmd_path(char **path, char *cmd);
 bool	ft_isapath(char *str);
 /*	GET_PATH	*/
-char	**ft_get_path(char **envp);
+char	**ft_get_path(t_list *env);
 /*	RUN	*/
 void	ft_run(t_msh *msh);
 

--- a/include/init.h
+++ b/include/init.h
@@ -5,8 +5,13 @@
 
 # define NO_LAST_COMMAND 0
 
+/*	ENV_INIT	*/
+int		ft_env_to_list(t_list *list, char **envp);
+void	ft_free_var(void *content);
+/*	STRUCT_DESTROY	*/
 int		ft_quit(t_msh *msh);
-t_msh	*ft_struct_init(char **envp);
 void	ft_free_cmd_list(t_pipeline *pipeline);
+/*	STRUCT_INIT	*/
+t_msh	*ft_struct_init(char **envp);
 
 #endif

--- a/include/list.h
+++ b/include/list.h
@@ -1,5 +1,5 @@
-#ifndef FT_LST_H
-# define FT_LST_H
+#ifndef LIST_H
+# define LIST_H
 
 # include <stddef.h>
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,15 +1,17 @@
 #ifndef UTILS_H
 # define UTILS_H
 
+# include "exec.h"
 # include <stddef.h>
 # include <stdint.h>
 
-char	*ft_getenv(const char *name, char **env);
+char	*ft_getenv(const char *name, t_list *env);
 void	*ft_calloc(size_t count, size_t size);
 char	**ft_dptrcpy(char **dptr);
 size_t	ft_dptrlen(char	**dptr);
 void	*ft_freef(const char *formats, ...);
 char	*ft_join(int argc, ...);
+void	*ft_memcpy(void *dst, const void *src, size_t n);
 void	ft_putendl_fd(const char *s, int fd);
 void	ft_putstr_fd(const char *s, int fd);
 char	**ft_split(char const *s, char c);
@@ -17,6 +19,7 @@ int		ft_strcmp(const char *s1, const char *s2);
 char	*ft_strdup(const char *s1);
 size_t	ft_strlen(const char *s);
 int		ft_strncmp(const char *s1, const char *s2, size_t n);
+char	*ft_strndup(const char *s1, size_t n);
 char	*ft_substr(const char *s, unsigned int start, size_t len);
 void	ft_umaxtostr(char *str, size_t len, uintmax_t n);
 

--- a/src/exec/exec.c
+++ b/src/exec/exec.c
@@ -18,8 +18,8 @@ int	ft_exec_line(t_msh *msh, t_pipeline *pipeline)
 
 	// pipeline->cmd_list = ft_calloc(1, sizeof(t_cmd));
 	// pipeline->n_cmd = 1;
-	// pipeline->cmd_list->n_redirect = 1;
-	// pipeline->cmd_list->args = ft_split("cat", ' ');
+	// pipeline->cmd_list->n_redirect = 0;
+	// pipeline->cmd_list->args = ft_split("env", ' ');
 	// pipeline->cmd_list->redirect_arr = ft_calloc(1, sizeof(t_redirect));
 	// pipeline->cmd_list->redirect_arr->file = ft_strdup("EOF");
 	// pipeline->cmd_list->redirect_arr->e_iotype = HEREDOC;
@@ -37,7 +37,7 @@ int	ft_exec_line(t_msh *msh, t_pipeline *pipeline)
 
 static int	ft_init_exl(t_exl *exl, t_msh *msh, t_pipeline *pipeline)
 {
-	exl->env = msh->env;
+	exl->env = &msh->env;
 	exl->path = msh->path;
 	exl->line_num = &msh->line_num;
 	exl->cmd_idx = -1;

--- a/src/exec/get_path.c
+++ b/src/exec/get_path.c
@@ -2,14 +2,14 @@
 #include "utils.h"
 #include <stdlib.h>
 
-char		**ft_get_path(char **envp);
+char		**ft_get_path(t_list *env);
 static char	**ft_set_slash(char **path);
 
-char	**ft_get_path(char **envp)
+char	**ft_get_path(t_list *env)
 {
 	char	**path;
 
-	path = ft_split(ft_getenv("PATH", envp), ':');
+	path = ft_split(ft_getenv("PATH", env), ':');
 	if (path == NULL)
 		return (NULL);
 	return (ft_set_slash(path));

--- a/src/init_and_destroy/env_init.c
+++ b/src/init_and_destroy/env_init.c
@@ -1,0 +1,70 @@
+#include "init.h"
+#include "utils.h"
+
+int				ft_env_to_list(t_list *list, char **envp);
+void			ft_free_var(void *content);
+static t_var	*ft_create_var(char *str);
+static size_t	ft_get_name_len(const char *var);
+
+int	ft_env_to_list(t_list *list, char **envp)
+{
+	t_var		*new_var;
+	t_list_node	*node;
+
+	while (envp != NULL && *envp != NULL)
+	{
+		new_var = ft_create_var(*envp);
+		node = ft_lstnew(new_var);
+		if (node == NULL || new_var == NULL)
+		{
+			ft_free_var(new_var);
+			ft_lstclear(&list->list_node, &ft_free_var);
+			return (-1);
+		}
+		if (list->last_node == NULL)
+			ft_lstadd_back(&list->list_node, node);
+		else
+			ft_lstadd_back(&list->last_node, node);
+		list->last_node = node;
+		++list->n_exported;
+		++envp;
+	}
+	return (0);
+}
+
+void	ft_free_var(void *content)
+{
+	t_var	*var;
+
+	if (content == NULL)
+		return ;
+	var = (t_var *)content;
+	ft_freef("%p%p%p", var->name, var->value, var);
+}
+
+static t_var	*ft_create_var(char *str)
+{
+	t_var		*new_var;
+	size_t		name_len;
+
+	new_var = ft_calloc(1, sizeof(t_var));
+	if (new_var == NULL)
+		return (NULL);
+	name_len = ft_get_name_len(str);
+	new_var->name = ft_strndup(str, name_len);
+	new_var->value = ft_strdup(str + name_len + 1);
+	if (new_var->name == NULL || new_var->value == NULL)
+		return (ft_freef("%p%p%p", new_var->name, new_var->value, new_var));
+	new_var->exported = true;
+	return (new_var);
+}
+
+static size_t	ft_get_name_len(const char *var)
+{
+	const char	*tmp;
+
+	tmp = var;
+	while (*tmp != '=')
+		++tmp;
+	return ((size_t)(tmp - var));
+}

--- a/src/init_and_destroy/struct_destroy.c
+++ b/src/init_and_destroy/struct_destroy.c
@@ -1,4 +1,5 @@
 #include "init.h"
+#include "list.h"
 #include "utils.h"
 #include <stdlib.h>
 
@@ -10,7 +11,8 @@ int	ft_quit(t_msh *msh)
 	int	exit_cpy;
 
 	exit_cpy = msh->exit_status;
-	ft_freef("%P%P%p", msh->env, msh->path, msh);
+	ft_lstclear(&msh->env.list_node, &ft_free_var);
+	ft_freef("%P%p", msh->path, msh);
 	return (exit_cpy);
 }
 

--- a/src/init_and_destroy/struct_init.c
+++ b/src/init_and_destroy/struct_init.c
@@ -1,7 +1,7 @@
 #include "init.h"
 #include "utils.h"
 
-t_msh	*ft_struct_init(char **envp);
+t_msh			*ft_struct_init(char **envp);
 
 t_msh	*ft_struct_init(char **envp)
 {
@@ -10,8 +10,7 @@ t_msh	*ft_struct_init(char **envp)
 	msh = ft_calloc(1, sizeof(t_msh));
 	if (msh == NULL)
 		return (NULL);
-	msh->env = ft_dptrcpy(envp);
-	if (msh->env == NULL)
+	if (ft_env_to_list(&msh->env, envp) == -1)
 		return (ft_freef("%p", msh));
 	return (msh);
 }

--- a/src/utils/env_utils.c
+++ b/src/utils/env_utils.c
@@ -1,14 +1,16 @@
+#include "exec.h"
 #include "utils.h"
 
-char	*ft_getenv(const char *name, char **env);
+char	*ft_getenv(const char *name, t_list *env);
 
-char	*ft_getenv(const char *name, char **env)
+char	*ft_getenv(const char *name, t_list *env)
 {
-	while (env != NULL && *env != NULL \
-			&& (ft_strncmp(*env, name, ft_strlen(name)) != 0 \
-			|| (*env)[ft_strlen(name)] != '='))
-		++env;
-	if (env == NULL || *env == NULL)
-		return (NULL);
-	return (*env + ft_strlen(name) + 1);
+	t_list_node	*node;
+
+	node = env->list_node;
+	while (node != NULL && ft_strcmp(name, ((t_var *)node->content)->name) != 0)
+		node = node->next;
+	if (node != NULL)
+		return (((t_var *)node->content)->value);
+	return (NULL);
 }

--- a/src/utils/ft_lst/ft_lstadd_back.c
+++ b/src/utils/ft_lst/ft_lstadd_back.c
@@ -1,4 +1,4 @@
-#include "ft_list.h"
+#include "list.h"
 #include <stddef.h>
 
 void	ft_lstadd_back(t_list_node **list_node, t_list_node *new_node);

--- a/src/utils/ft_lst/ft_lstadd_front.c
+++ b/src/utils/ft_lst/ft_lstadd_front.c
@@ -1,4 +1,4 @@
-#include "ft_list.h"
+#include "list.h"
 #include <stddef.h>
 
 void	ft_lstadd_front(t_list_node **list_node, t_list_node *new_node);

--- a/src/utils/ft_lst/ft_lstclear.c
+++ b/src/utils/ft_lst/ft_lstclear.c
@@ -1,4 +1,4 @@
-#include "ft_list.h"
+#include "list.h"
 #include <stddef.h>
 
 void	ft_lstclear(t_list_node **list_node, del_func *del_func);

--- a/src/utils/ft_lst/ft_lstdelone.c
+++ b/src/utils/ft_lst/ft_lstdelone.c
@@ -1,4 +1,4 @@
-#include "ft_list.h"
+#include "list.h"
 #include <stddef.h>
 #include <stdlib.h>
 

--- a/src/utils/ft_lst/ft_lstlast.c
+++ b/src/utils/ft_lst/ft_lstlast.c
@@ -1,4 +1,4 @@
-#include "ft_list.h"
+#include "list.h"
 #include <stddef.h>
 
 t_list_node	*ft_lstlast(t_list_node *list_node);

--- a/src/utils/ft_lst/ft_lstnew.c
+++ b/src/utils/ft_lst/ft_lstnew.c
@@ -1,4 +1,4 @@
-#include "ft_list.h"
+#include "list.h"
 #include "utils.h"
 
 t_list_node	*ft_lstnew(void *content);

--- a/src/utils/ft_lst/ft_lstsize.c
+++ b/src/utils/ft_lst/ft_lstsize.c
@@ -1,4 +1,4 @@
-#include "ft_list.h"
+#include "list.h"
 #include <stddef.h>
 
 size_t	ft_lstsize(t_list_node *list_node);

--- a/src/utils/ft_memcpy.c
+++ b/src/utils/ft_memcpy.c
@@ -1,0 +1,17 @@
+#include "utils.h"
+
+void	*ft_memcpy(void *dst, const void *src, size_t n);
+
+void	*ft_memcpy(void *dst, const void *src, size_t n)
+{
+	char		*cast_dst;
+	const char	*cast_src;
+
+	cast_dst = (char *)dst;
+	cast_src = (const char *)src;
+	if (n == 0 || cast_src == cast_dst)
+		return (dst);
+	while (n-- != 0)
+		*cast_dst++ = *cast_src++;
+	return (dst);
+}

--- a/src/utils/ft_strdup.c
+++ b/src/utils/ft_strdup.c
@@ -1,7 +1,6 @@
 #include "utils.h"
 
 char		*ft_strdup(const char *s1);
-static void	*ft_memcpy(void *dst, const void *src, size_t n);
 
 char	*ft_strdup(const char *s1)
 {
@@ -12,18 +11,4 @@ char	*ft_strdup(const char *s1)
 	if (s2 == NULL)
 		return (NULL);
 	return (ft_memcpy(s2, s1, size + 1));
-}
-
-static void	*ft_memcpy(void *dst, const void *src, size_t n)
-{
-	char		*cast_dst;
-	const char	*cast_src;
-
-	cast_dst = (char *)dst;
-	cast_src = (const char *)src;
-	if (n == 0 || cast_src == cast_dst)
-		return (dst);
-	while (n-- != 0)
-		*cast_dst++ = *cast_src++;
-	return (dst);
 }

--- a/src/utils/ft_strndup.c
+++ b/src/utils/ft_strndup.c
@@ -1,0 +1,17 @@
+#include "utils.h"
+
+char	*ft_strndup(const char *s1, size_t n);
+
+char	*ft_strndup(const char *s1, size_t n)
+{
+	size_t	size;
+	char	*s2;
+
+	size = ft_strlen(s1);
+	if (n < size)
+		size = n;
+	s2 = ft_calloc(size + 1, sizeof(*s2));
+	if (s2 == NULL)
+		return (NULL);
+	return (ft_memcpy(s2, s1, size));
+}


### PR DESCRIPTION
Changes how env is handled:
Env is now a linked list where each node content is a shell variable (t_var whit a name, value, and export flag).

Much easier to use for builtins.

Adds a bunch of functions for linked lists.
